### PR TITLE
Update Dynamo examples to correct reference

### DIFF
--- a/doc_source/welcome.md
+++ b/doc_source/welcome.md
@@ -169,13 +169,13 @@ The following example uses the V2 `createBucket` command to create a DynamoDB ta
 
 ```
 const {DynamoDB} = require('@aws-sdk/client-dynamodb');
-const DymamoDB = new DynamoDB({region: 'us-west-2'});
+const dymamoDB = new DynamoDB({region: 'us-west-2'});
 var tableParams = {
     TableName : TABLE_NAME
 };
 async function run() => {
       try {
-           const data = s3.createTable(tableParams);
+           const data = dynamoDB.createTable(tableParams);
            console.log("Success", data);
       } 
       catch (err) {
@@ -189,13 +189,13 @@ The following example uses the V2 `createBucket` command to create a DynamoDB ta
 
 ```
 const {DynamoDB} = require('@aws-sdk/client-dynamodb');
-const DymamoDB = new DynamoDB({region: 'us-west-2'});
+const dymamoDB = new DynamoDB({region: 'us-west-2'});
 var tableParams = {
     TableName : TABLE_NAME
 };
 async function run() => {
       try {
-           const data = s3.createTable(tableParams);
+           const data = dynamoDB.createTable(tableParams);
            console.log("Success", data);
       } 
       catch (err) {


### PR DESCRIPTION
V2 examples instantiate DynamoDB but us "s3.vcreateTeable" I updated to a lower case `dynamoDB` and `dynamoDB.createTable`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
