### PR TITLE
fix: webpack command for Getting Started with Browser

### DIFF
--- a/doc_source/getting-started-browser.md
+++ b/doc_source/getting-started-browser.md
@@ -192,8 +192,9 @@ Finally, run the following at the command prompt to bundle the JavaScript for th
 ```
 
 **Note**  
-For information about installing webpack, see [Bundling applications wi
-The full JavaScript page is available [here on GitHub](https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/javascriptv3/example_code/polly/src/polly.js)\.
+For information about installing webpack, see [Bundling applications with webpack](webpack.md)\.
+
+The full JavaScript page is available [here on GitHub](https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/javascriptv3/example_code/polly/src/polly.ts)\.
 
 ## Step 6: Run the Example<a name="getting-started-browser-run-sample"></a>
 

--- a/doc_source/getting-started-browser.md
+++ b/doc_source/getting-started-browser.md
@@ -188,7 +188,7 @@ After you create the presigner object, call the `getSynthesizeSpeechUrl` method 
 Finally, run the following at the command prompt to bundle the JavaScript for this example in a file named `main.js`:
 
 ```
-./node_modules/.bin/webpack polly.ts --mode development --target web --devtool false -o main.js
+./node_modules/.bin/webpack --entry ./polly.ts --mode development --target web --devtool false -o main.js
 ```
 
 **Note**  

--- a/doc_source/getting-started-browser.md
+++ b/doc_source/getting-started-browser.md
@@ -188,7 +188,7 @@ After you create the presigner object, call the `getSynthesizeSpeechUrl` method 
 Finally, run the following at the command prompt to bundle the JavaScript for this example in a file named `main.js`:
 
 ```
-webpack polly.js --mode development --target web --devtool false -o main.js
+./node_modules/.bin/webpack polly.ts --mode development --target web --devtool false -o main.js
 ```
 
 **Note**  

--- a/doc_source/getting-started-browser.md
+++ b/doc_source/getting-started-browser.md
@@ -188,12 +188,11 @@ After you create the presigner object, call the `getSynthesizeSpeechUrl` method 
 Finally, run the following at the command prompt to bundle the JavaScript for this example in a file named `main.js`:
 
 ```
-./node_modules/.bin/webpack --entry ./polly.js --mode development --target web --devtool false -o main.js
+./node_modules/.bin/webpack --entry ./polly.js --mode development --target web -o main.js
 ```
 
 **Note**  
-For information about installing webpack, see [Bundling applications with webpack](webpack.md)\.
-
+For information about installing webpack, see [Bundling applications wi
 The full JavaScript page is available [here on GitHub](https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/javascriptv3/example_code/polly/src/polly.js)\.
 
 ## Step 6: Run the Example<a name="getting-started-browser-run-sample"></a>

--- a/doc_source/getting-started-browser.md
+++ b/doc_source/getting-started-browser.md
@@ -188,13 +188,13 @@ After you create the presigner object, call the `getSynthesizeSpeechUrl` method 
 Finally, run the following at the command prompt to bundle the JavaScript for this example in a file named `main.js`:
 
 ```
-./node_modules/.bin/webpack --entry ./polly.ts --mode development --target web --devtool false -o main.js
+./node_modules/.bin/webpack --entry ./polly.js --mode development --target web --devtool false -o main.js
 ```
 
 **Note**  
 For information about installing webpack, see [Bundling applications with webpack](webpack.md)\.
 
-The full JavaScript page is available [here on GitHub](https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/javascriptv3/example_code/polly/src/polly.ts)\.
+The full JavaScript page is available [here on GitHub](https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/javascriptv3/example_code/polly/src/polly.js)\.
 
 ## Step 6: Run the Example<a name="getting-started-browser-run-sample"></a>
 

--- a/doc_source/getting-started-browser.md
+++ b/doc_source/getting-started-browser.md
@@ -188,7 +188,7 @@ After you create the presigner object, call the `getSynthesizeSpeechUrl` method 
 Finally, run the following at the command prompt to bundle the JavaScript for this example in a file named `main.js`:
 
 ```
-./node_modules/.bin/webpack --entry ./polly.js --mode development --target web -o main.js
+./node_modules/.bin/webpack --entry ./polly.js --mode development --target web
 ```
 
 **Note**  


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
fix webpack command under ["Getting Started with Browser"](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/getting-started-browser.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
