### PR TITLE
docs: fix missing SQS Delete paramter when issuing DeleteMessageCommand

### DIFF
--- a/doc_source/sqs-examples-send-receive-messages.md
+++ b/doc_source/sqs-examples-send-receive-messages.md
@@ -146,7 +146,7 @@ const run = async () => {
         ReceiptHandle: data.Messages[0].ReceiptHandle,
       };
       try {
-        const data = await sqs.send(new DeleteMessageCommand({}));
+        const data = await sqs.send(new DeleteMessageCommand(deleteParams));
       } catch (err) {
         console.log("Message Deleted", data);
       }


### PR DESCRIPTION
*Description of changes:*
The documentation for Deleting the mesage from SQS Queue was missing the delete parameter. Fixed the documentation for the same

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
