### PR TITLE
Set filestream when uploading file

### DIFF
--- a/doc_source/s3-example-creating-buckets.md
+++ b/doc_source/s3-example-creating-buckets.md
@@ -151,6 +151,7 @@ const run = async () => {
     console.log("File Error", err);
   });
   uploadParams.Key = path.basename(file);
+  uploadParams.Body = fileStream;
   // call S3 to retrieve upload file to specified bucket
   try {
     const data = await s3.send(new PutObjectCommand(uploadParams));


### PR DESCRIPTION
Currently `fileStream` is unused and the example uploads a static string as the object contents. 
It should be set to `uploadParams.Body` so the file will get uploaded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
