### PR TITLE
correct typo and clean up indenting

### DIFF
--- a/doc_source/webpack.md
+++ b/doc_source/webpack.md
@@ -126,7 +126,7 @@ To use the bundle in a browser script, you can incorporate the bundle using a `<
 
 ## Bundling for Node\.js<a name="webpack-nodejs-bundles"></a>
 
-You can use `webpack` to generate bundles that run in Node\.js by specifying `webpack` as a target in the configuration\.
+You can use `webpack` to generate bundles that run in Node\.js by specifying `node` as a target in the configuration\.
 
 ```
 target: "node"
@@ -148,16 +148,16 @@ module.exports = {
   // Let webpack know to generate a Node.js bundle.
   target: "node",
    // Enable WebPack to use the 'path' package.
-   resolve:{
-  fallback: { path: require.resolve("path-browserify"}
+  resolve:{
+    fallback: { path: require.resolve("path-browserify"}
   }
-   /**
-   * In Webpack version v2.0.0 and earlier, you must tell 
-   * webpack how to use "json-loader" to load 'json' files.
-   * To do this Enter 'npm --save-dev install json-loader' at the 
-   * command line to install the "json-loader' package, and include the 
-   * following entry in your webpack.config.js.
-   module: {
+  /**
+  * In Webpack version v2.0.0 and earlier, you must tell 
+  * webpack how to use "json-loader" to load 'json' files.
+  * To do this Enter 'npm --save-dev install json-loader' at the 
+  * command line to install the "json-loader' package, and include the 
+  * following entry in your webpack.config.js:
+  module: {
     rules: [{test: /\.json$/, use: use: "json-loader"}]
   }
   **/


### PR DESCRIPTION
*Issue #, if available:*
_n/a_

*Description of changes:*
- Line 129 specifies `node` as the target (not `webpack`) to match line 149 in the example.
- Lines 151-163 have their indentation adjusted to be consistent with the rest of the block
- Line 159 uses a colon to introduce the entry below it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
