### PR TITLE
fix: SDK assumes maxSockets=50 only when not defined

### DIFF
--- a/doc_source/node-configuring-maxsockets.md
+++ b/doc_source/node-configuring-maxsockets.md
@@ -29,6 +29,6 @@ var dynamodbClient = new DynamoDBClient({
 });
 ```
 
-When using the default of `https`, the SDK takes the `maxSockets` value from the `globalAgent`\. If the `maxSockets` value is not defined or is `Infinity`, the SDK assumes a `maxSockets` value of 50\.
+When using the default of `https`, the SDK takes the `maxSockets` value from the `globalAgent`\. If the `maxSockets` value is not defined, the SDK assumes a `maxSockets` value of 50\.
 
 For more information about setting `maxSockets` in Node\.js, see the [Node\.js online documentation](https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_agent_maxsockets)\.


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2024

*Description of changes:*
JS SDK v3 assumes maxSockets=50 only when it's not defined, and not when it's explicitly set to `Infinity`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
