### PR TITLE
doc: fix tag version

### DIFF
--- a/doc_source/getting-started-nodejs.md
+++ b/doc_source/getting-started-nodejs.md
@@ -44,8 +44,8 @@ For details about using `package.json` in a Node\.js project, see [What is the f
      "main": "index.js",
      "dependencies": {
       "@aws-sdk/client-s3": "^3.3.0",
-       "@aws-sdk/node-http-handler": "^^3.3.0",
-       "@aws-sdk/types": "^^3.3.0",
+       "@aws-sdk/node-http-handler": "^3.3.0",
+       "@aws-sdk/types": "^3.3.0",
        "ts-node": "^9.0.0"
      },
      "devDependencies": {


### PR DESCRIPTION
code EINVALIDTAGNAME
Invalid tag name "^^3.3.0": Tags may not have any characters that encodeURIComponent encodes.


*Description of changes:*
npm install failed due to invalid tag name.
Node v12.12.0
npm v6.11.3
Mac OS Bigsur


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
