### PR TITLE
Fix fromCognitoIdentityPool parameters

### DIFF
--- a/doc_source/loading-browser-credentials-cognito.md
+++ b/doc_source/loading-browser-credentials-cognito.md
@@ -54,8 +54,8 @@ FB.login(function (response) {
       region: "us-west-2",
       credentials: fromCognitoIdentityPool({
         client: cognitoIdentityClient,
-        IdentityPoolId: 'IDENTITY_POOL_ID',
-        Logins: {
+        identityPoolId: 'IDENTITY_POOL_ID',
+        logins: {
            "graph.facebook.com': 'response.authResponse.accessToken"
         },
       }),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed fromCognitoIdentityPool parameters in the Facebook login example to be the same as parameters in the official documentation: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/modules/_aws_sdk_credential_provider_cognito_identity.html#fromcognitoidentitypool-1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
