### PR TITLE
Fix example for configuring proxies

### DIFF
--- a/doc_source/node-configuring-proxies.md
+++ b/doc_source/node-configuring-proxies.md
@@ -12,21 +12,21 @@ If you can't directly connect to the internet, the SDK for JavaScript supports u
 
 To find a third\-party HTTP agent, search for "HTTP proxy" at [npm](https://www.npmjs.com/)\.
 
-To install a third\-party HTTP agent proxy, enter the following at the command prompt, where *PROXY* is the name of the `npm` package\. 
+To install a third\-party HTTP agent proxy, enter the following at the command prompt, where *PROXY* is the name of the `npm` package\.
 
 ```
 npm install PROXY --save
 ```
 
-To use a proxy in your application, use the `httpOptions` property, as shown in the following example for a DynamoDB client\. 
+To use a proxy in your application, use the `httpOptions` property, as shown in the following example for a DynamoDB client\.
 
 ```
-const proxy = require("proxy-agent");
+const ProxyAgent = require("proxy-agent");
 const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
 
 const dynamodbClient = new DynamoDBClient({
   requestHandler: new NodeHttpHandler({
-    httpAgent: new Agent({ proxy: proxy("http://internal.proxy.com") }),
+    httpAgent: new ProxyAgent("http://internal.proxy.com"),
   }),
 });
 ```


### PR DESCRIPTION
*Issue #, if available:*
closes #49

*Description of changes:*
This change fixes the example for configuring proxies. Previously we were
passing the proxy-agent into the `Agent` constructor, however, this did
not match the call signature for Agent.

See https://github.com/TooTallNate/node-proxy-agent#example

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
