### PR TITLE
Change sample.ts to sample.js in link

### DIFF
--- a/doc_source/getting-started-nodejs.md
+++ b/doc_source/getting-started-nodejs.md
@@ -131,7 +131,7 @@ The example code can be found [here on GitHub](https://github.com/awsdocs/aws-do
 Enter the following command to run the example\.
 
 ```
-node sample.ts
+node sample.js
 ```
 
 If the upload is successful, you'll see a confirmation message at the command prompt\. You can also find the bucket and the uploaded text object in the [Amazon S3 console](https://console.aws.amazon.com/s3/)\.

--- a/doc_source/getting-started-nodejs.md
+++ b/doc_source/getting-started-nodejs.md
@@ -124,7 +124,7 @@ const run = async () => {
 run();
 ```
 
-The example code can be found [here on GitHub](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/javascriptv3/example_code/nodegetstarted/src/sample.ts)\.
+The example code can be found [here on GitHub](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/javascriptv3/example_code/nodegetstarted/src/sample.js)\.
 
 ## Step 3: Run the example<a name="getting-started-nodejs-run-sample"></a>
 


### PR DESCRIPTION
Seems like the file was changed to javascript from typescript, but the link was not updated along with it. Was 404.

My edit changes the link to fix the 404.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
