### PR TITLE
Fixed Typo in NodeJS documentation

### DIFF
--- a/doc_source/getting-started-nodejs.md
+++ b/doc_source/getting-started-nodejs.md
@@ -62,7 +62,7 @@ For details about using `package.json` in a Node\.js project, see [What is the f
 
    The packages and dependencies are installed\. 
 **Note**  
-You can add dependencies to the `package.json` and install them by running `npm install`\. You can also add dependancies directly through the command line\. For example, to install the AWS SDK for JavaScript v3 client module for Amazon S3, enter the command below in the command line\.  
+You can add dependencies to the `package.json` and install them by running `npm install`\. You can also add dependencies directly through the command line\. For example, to install the AWS SDK for JavaScript v3 client module for Amazon S3, enter the command below in the command line\.  
 
    ```
    npm install @aws-sdk/client-s3


### PR DESCRIPTION
Fixed a typo that mentioned **dependancy** instead of **dependency** as indicated by the commit.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
