### PR TITLE
Fix wrong syntax in MediaFileUri example

### DIFF
--- a/doc_source/transcribe-examples-section.md
+++ b/doc_source/transcribe-examples-section.md
@@ -60,7 +60,7 @@ const params = {
   MediaFormat: "SOURCE_FILE_FORMAT", // For example, 'wav'
   Media: {
     MediaFileUri: "SOURCE_LOCATION",
-    // For example, "https://transcribe-demo.s3-REGION.amazonaws.com/hello_world.wav"
+    // For example, "https://transcribe-demo.s3.REGION.amazonaws.com/hello_world.wav"
   },
 };
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Replaced the dash with a period, as per https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
