### PR TITLE
Removed deprecated Node.js version from the link

### DIFF
--- a/doc_source/node-js-considerations.md
+++ b/doc_source/node-js-considerations.md
@@ -33,7 +33,7 @@ fs.readFile('index.html', function(err, data) {
 });
 ```
 
-For a complete list of all built\-in modules that Node\.js provides, see [Node\.js v6\.11\.1 documentation](https://nodejs.org/api/modules.html) on the Node\.js website\.
+For a complete list of all built\-in modules that Node\.js provides, see [Node\.js documentation](https://nodejs.org/api/modules.html) on the Node\.js website\.
 
 ## Using npm packages<a name="node-npm-packages"></a>
 


### PR DESCRIPTION
Removed deprecated Node.js version 6.11.1 from the API link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
