### PR TITLE
Fix wrong variable name in creating presigned url example

### DIFF
--- a/doc_source/s3-example-creating-buckets.md
+++ b/doc_source/s3-example-creating-buckets.md
@@ -584,7 +584,9 @@ export const run = async () => {
   try {
     // Delete the S3 bucket.
     console.log(`\nDeleting bucket ${bucketParams.Bucket}`);
-    await s3.send(new DeleteBucketCommand({ Bucket: bucketParams.Bucket }));
+    await s3Client.send(
+      new DeleteBucketCommand({ Bucket: bucketParams.Bucket })
+    );
   } catch (err) {
     console.log("Error deleting bucket", err);
   }


### PR DESCRIPTION
*Issue #, if available:*
#83 

*Description of changes:*
Fix wrong variable name `s3`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
