### PR TITLE
Fix profile fromIni usage

### DIFF
--- a/doc_source/loading-node-credentials-shared.md
+++ b/doc_source/loading-node-credentials-shared.md
@@ -50,7 +50,7 @@ $ node script.js
 You can also explicitly select the profile used by a client, as shown in the following example\.
 
 ```
-const {fromIni} = require("@aws-sdk/credential-provider-ini");
+const {fromIni} = require("@aws-sdk/credential-providers");
 const s3Client = new S3.S3Client({
   credentials: fromIni({profile: 'work-account'})
 });


### PR DESCRIPTION
*Description of changes:*

Docs told me to use `const {fromIni} = require("@aws-sdk/credential-provider-ini");` but I got:
```
CredentialsProviderError: Profile [myprofile] requires a role to be assumed, but no role assumption callback was provided.
```
When I looked at https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/modules/_aws_sdk_credential_provider_ini.html it said:
> Usage
> You probably shouldn't, at least directly. Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers) instead.

I changed to import `fromIni` from there instead, and it worked as I would expect, so I think that's what these docs should say.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
