### PR TITLE
fix: remove incorrect s3.send line from example

### DIFF
--- a/doc_source/s3-example-photo-album-full.md
+++ b/doc_source/s3-example-photo-album-full.md
@@ -230,12 +230,6 @@ const addPhoto = async (albumName) => {
   const files = document.getElementById("photoupload").files;
   try {
     const albumPhotosKey = encodeURIComponent(albumName) + "/";
-    const data = await s3.send(
-        new ListObjectsCommand({
-          Prefix: albumPhotosKey,
-          Bucket: albumBucketName
-        })
-    );
     const file = files[0];
     const fileName = file.name;
     const photoKey = albumPhotosKey + fileName;


### PR DESCRIPTION
The ListObjectCommand was for the viewAlbum function, and in this case throws an error because of duplicate `const data` declarations in the same block. Most likely it was a copy/paste error that wasn't removed



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
