### PR TITLE
Mention aws-sdk-js-codemod in migration guide

### DIFF
--- a/doc_source/migrating-to-v3.md
+++ b/doc_source/migrating-to-v3.md
@@ -8,143 +8,46 @@ Help us improve the AWS SDK for JavaScript version 3 \(V3\) documentation by pro
 
 # Migrating your code to SDK for JavaScript V3<a name="migrating-to-v3"></a>
 
-There are a number of migration paths to the SDK for JavaScript version 3 \(V3\)\. To take full advantage of the reduction in capacity potential of V3, we recommend using path 3\.
-
-**Important**  
 AWS SDK for JavaScript version 3 \(v3\) also comes with modernized interfaces for client configurations and utilities, which include credentials, Amazon S3 multipart upload, DynamoDB document client, waiters, and so forth\)\. You can find what changed in v2 and the v3 equivalents for each change in the [migration guide on the AWS SDK for JavaScript GitHub repo](https://github.com/aws/aws-sdk-js-v3/blob/main/UPGRADING.md)\.
 
-------
-#### [ Path 1 ]
+The experimental collection of codemod scripts in [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod) helps migrate your existing AWS SDK for JavaScript (v2) application to use v3 APIs\. You can run the transform as follows:
 
-Perform minimal changes:
-+ Install only the specific AWS Service packages you need\.
-+ Create and use V3 service clients, replacing the use of any global configuration values, such as Region, with configuration values passed in as arguments to the client\. 
-**Note**  
-You can set the AWS Region using an environment variable, or a shared configuration `config` file\. For more information, see [Setting credentials in Node\.js](https://docs.aws.amazon.com/en_us/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html)\.
-
-------
-#### [ Path 2 ]
-
-Follow path 1 and remove `.promise`, which are not required in V3\.
-
-------
-#### [ Path 3 ]
-
-Follow path 1 and use the async/await programming model\.
-
-------
-
-**Important**  
-For information about significant changes from AWS SDK for JavaScript v2 to v3, please see [Upgrading Notes \(2\.x to 3\.x\)](https://github.com/aws/aws-sdk-js-v3/blob/main/UPGRADING.md) on GitHub\.
-
-The following sections describe these paths in detail, with examples\.
-
-## Path 1 example<a name="path1-examples"></a>
-
-The following code installs the AWS Service package for Amazon S3\. 
-
-```
-npm install @aws-sdk/client-s3
+```console
+$ npx aws-sdk-js-codemod -t v2-to-v3 PATH...
 ```
 
-The following code loads the Amazon S3 service\.
+For example, consider you have the following code, which creates a Amazon DynamoDB client from v2 and calls listTables operation:
 
-```
-import {S3} from '@aws-sdk/client-s3';
-```
+```ts
+// example.ts
+import AWS from "aws-sdk";
 
-**Note**  
-To use this approach you must import the full AWS Service packages, `S3` in this case, and not just the service clients\.
-
-The following code creates an Amazon S3 service object in the `us-west-2` Region\.
-
-```
-const client = new S3({region: 'us-west-2'});
-```
-
-The following code creates and Amazon S3 bucket using a callback function, using the following syntax from V2\.
-
-```
-client.command(parameters)
+const region = "us-west-2";
+const client = new AWS.DynamoDB({ region });
+client.listTables({}, (err, data) => {
+  if (err) console.log(err, err.stack);
+  else console.log(data);
+});
 ```
 
-```
-import {S3} from '@aws-sdk/client-s3';
-const client = new S3({region: 'us-west-2'});
-const bucketParams = {
-    Bucket : BUCKET_NAME
-};
-function run(){
-         client.createBucket(bucketParams, function(err, data) {
-         if (err) {
-         console.log("Error", err);
-         } else {
-         console.log("Success", data.Location);
-         }
-    })
-};
-run();
+You can run our `v2-to-v3` transform on `example.ts` as follows:
+
+```console
+$ npx aws-sdk-js-codemod -t v2-to-v3 example.ts
 ```
 
-## Path 2 example<a name="path2-examples"></a>
+The transform will convert the DynamoDB import to v3, create v3 client and call listTables operation as follows:
 
-Here is a function call in V2 using a `promise`\.
+```ts
+// example.ts
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
-```
-const data =  await v2client.command(params).promise()
-```
-
-Here is the V3 version\.
-
-```
-const data = await v3client.command(params)
-```
-
-## Path 3 examples<a name="path3-examples"></a>
-
-The following command installs the AWS Service package for Amazon S3\.
-
-```
-npm install @aws-sdk/client-s3; 
+const region = "us-west-2";
+const client = new DynamoDB({ region });
+client.listTables({}, (err, data) => {
+  if (err) console.log(err, err.stack);
+  else console.log(data);
+});
 ```
 
-The following code loads only the Amazon S3 client, reducing the overhead\.
-
-```
-import {S3Client, CreateBucketCommand} from '@aws-sdk/client-s3';
-```
-
- If you install only the client of a package, you must also import the V3 commands you want to use\. In this case, the code imports the `CreateBucketCommand`, which enables you to create an Amazon S3 bucket\. You can browse the available commands in your project's `node-modules/@aws-sdk/client-PACKAGE_NAME/commands` folder\. 
-
-The following code creates an Amazon S3 service client object in the `us-west-2` Region\. 
-
-```
-const client = new S3Client({region: 'us-west-2'});
-```
-
-To call imported commands using the recommended async/await pattern, you must import the commands you want to use, and use the following syntax to run the command\.
-
-```
-  CLIENT.send(newXXXCommand)
-```
-
-The following example creates an Amazon S3 bucket using the async/await pattern, using only the client of the Amazon S3 service package to reduce overhead\.
-
-```
-import {S3Client, CreateBucketCommand} from '@aws-sdk/client-s3';
-const client = new S3Client({region: 'us-west-2'});
-const bucketParams = {
-    Bucket : BUCKET_NAME
-};
-
-(async function () {
-      try{
-        const data = await client.send(new CreateBucketCommand(bucketParams));
-        console.log("Success", data);
-      } catch (err) {
-        console.log("Error", err);
-      }
-})();
-```
-
-For more examples, see [SDK for JavaScript code examples](sdk-code-samples.md)\.
+We’ve implemented transforms for common use-cases\. If your code doesn’t transform correctly, please create a [bug report](https://github.com/awslabs/aws-sdk-js-codemod/issues/new?assignees=&labels=bug%2Ctriage&template=bug_report.yml&title=%5BBug%3F%5D%3A+) or [feature request](https://github.com/awslabs/aws-sdk-js-codemod/issues/new?assignees=&labels=enhancement&template=feature_request.yml&title=%5BFeature%5D%3A+) with example input code and observed/expected output code\. If your specific use case is already reported in [an existing issue](https://github.com/awslabs/aws-sdk-js-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc), show your support by an up-vote\.


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3639

*Description of changes:*
The AWS SDK for JavaScript team officially recommends `aws-sdk-js-codemod` transform in the [blog post](https://aws.amazon.com/blogs/developer/why-and-how-you-should-use-aws-sdk-for-javascript-v3-on-node-js-18/). This recommendation need to be provided in Developer Guide too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
