### PR TITLE
fix(doc): PutObjectCommand code example

### DIFF
--- a/doc_source/s3-example-creating-buckets.md
+++ b/doc_source/s3-example-creating-buckets.md
@@ -181,13 +181,13 @@ export const bucketParams = {
 export const run = async () => {
   try {
     const data = await s3Client.send(new PutObjectCommand(bucketParams));
-    return data; // For unit tests.
     console.log(
       "Successfully uploaded object: " +
         bucketParams.Bucket +
         "/" +
         bucketParams.Key
     );
+    return data; // For unit tests.
   } catch (err) {
     console.log("Error", err);
   }


### PR DESCRIPTION
`console.log` can't be after `return`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
